### PR TITLE
Fixed `start` method failure on started server.

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ class StaticServer {
 
 	start() {
 		if( this.running ){
-			return new new Promise((resolve, reject) => {
+			return new Promise((resolve, reject) => {
 				resolve(this.origin);
 			});
 		}


### PR DESCRIPTION
Fixed a typo in the `start` method that threw an exception on an attempt of starting already running server.