### PR TITLE
Fix start() if running, and start() and kill() when keepAlive is true.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ class StaticServer {
 
 		this.started = false;
 		this._origin = undefined;
+		this._handleAppStateChangeFn = this._handleAppStateChange.bind(this);
 	}
 
 	start() {
@@ -65,7 +66,7 @@ class StaticServer {
 		this.running = true;
 
 		if (!this.keepAlive && (Platform.OS === 'android')) {
-			AppState.addEventListener('change', this._handleAppStateChange.bind(this));
+			AppState.addEventListener('change', this._handleAppStateChangeFn);
 		}
 
 		return FPStaticServer.start(this.port, this.root, this.localOnly, this.keepAlive)
@@ -85,7 +86,7 @@ class StaticServer {
 		this.stop();
 		this.started = false;
 		this._origin = undefined;
-		AppState.removeEventListener('change', this._handleAppStateChange.bind(this));
+		AppState.removeEventListener('change', this._handleAppStateChangeFn);
 	}
 
 	_handleAppStateChange(appState) {

--- a/index.js
+++ b/index.js
@@ -58,9 +58,7 @@ class StaticServer {
 
 	start() {
 		if( this.running ){
-			return new new Promise((resolve, reject) => {
-				resolve(this.origin);
-			});
+			return Promise.resolve(this.origin);
 		}
 
 		this.started = true;


### PR DESCRIPTION
The first commit fixes the double new typo if already running and start() is called. Note, I didn't notice until making this PR that this is already addressed in #60 , So feel free to ignore, but Promise.resolve(value) is a little simpler.

Second, I fixed the event listener config when keepAlive is true for the change event on AppState. The addEventListener, and removeEventListener calls where both being called with `this._handleAppStateChange.bind(this)` which will actually result in a different function each time, i.e. `fn.bind(obj) !== fn.bind(obj)` so it is possible the the change event handler will still be registered after `kill()` has been called. Fixed this by creating a bound function `this._handleAppStateChangeFn` in the constructor that both calls to addEventListener/removeEventListener reference.

Great module - thanks for your awesome work! 