### PR TITLE
Update podspec homepage to fix react native link

### DIFF
--- a/react-native-static-server.podspec
+++ b/react-native-static-server.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description    = package['description']
   s.license        = package['license']
   s.author         = package['author']
-  s.homepage       = package['homepage']
+  s.homepage       = package['repository']
   s.source         = { :git => 'https://github.com/futurepress/react-native-static-server.git' }
 
   s.requires_arc   = true


### PR DESCRIPTION
I kept on getting the following error when running `react native link`
```
[!] The `react-native-static-server` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: Git sources should specify a tag.
    - WARN  | description: The description is equal to the summary.
```

Switching the homepage to point at the repository link fixes this.