### PR TITLE
Revert "Update podspec homepage to fix react native link"

### DIFF
--- a/react-native-static-server.podspec
+++ b/react-native-static-server.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description    = package['description']
   s.license        = package['license']
   s.author         = package['author']
-  s.homepage       = package['repository']
+  s.homepage       = package['homepage']
   s.source         = { :git => 'https://github.com/futurepress/react-native-static-server.git' }
 
   s.requires_arc   = true


### PR DESCRIPTION
Revert https://github.com/futurepress/react-native-static-server/pull/63 because https://github.com/futurepress/react-native-static-server/pull/75 fixed this issue.

`package['repository']` doesn't work in some cases because npm generate different package.json on `npm i` or `npm ci`.
It doesn't work when it's an object.
```
  "repository": {
    "type": "git",
    "url": "git+https://github.com/futurepress/react-native-static-server.git"
  }
```

`s.homepage     = package['homepage']` is used by a lot of libs. You can check async-storage for instance
https://github.com/react-native-community/async-storage/blob/LEGACY/RNCAsyncStorage.podspec#L12