### PR TITLE
set cacheAge to 0 so resources are always revalidated like on Android

### DIFF
--- a/ios/FPStaticServer.m
+++ b/ios/FPStaticServer.m
@@ -77,7 +77,7 @@ RCT_EXPORT_METHOD(start: (NSString *)port
     NSString *basePath = @"/";
     NSString *directoryPath = self.www_root;
     NSString *indexFilename = @"index.html";
-    NSUInteger cacheAge = 3600;
+    NSUInteger cacheAge = 0;
     BOOL allowRangeRequests = YES;
     [_webServer addHandlerWithMatchBlock:^GCDWebServerRequest*(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery) {
         if (![requestMethod isEqualToString:@"GET"]) {


### PR DESCRIPTION
I occasionally need to update files that I am serving with react-native-static-server. I noticed that my Android app will always get the latest file from the server, whereas on iOS it doesn't always update right away. This is because iOS has the `Cache-Control: cache-age=3600` header which tells the client to hold onto the resource for an hour. This change disables the caching so iOS behaves like Android.