### PR TITLE
Expect BOOLs not pointers to BOOLs

### DIFF
--- a/ios/FPStaticServer.m
+++ b/ios/FPStaticServer.m
@@ -32,8 +32,8 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(start: (NSString *)port
                   root:(NSString *)optroot
-                  localOnly:(BOOL *)localhost_only
-                  keepAlive:(BOOL *)keep_alive
+                  localOnly:(BOOL)localhost_only
+                  keepAlive:(BOOL)keep_alive
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
 


### PR DESCRIPTION
If we attempt to read these as pointers to BOOLs, they end up, as far as I can tell,
always evaluating to false / NO. I verified this behavior on my own machine.

OSX: 10.15.2
iOS: 13.3
iPhone model: 6s
Cocoapods: 1.9.1