### PR TITLE
Support for react-native-macos

### DIFF
--- a/ios/FPStaticServer.m
+++ b/ios/FPStaticServer.m
@@ -140,7 +140,9 @@ RCT_EXPORT_METHOD(start: (NSString *)port
     }
 
     if (self.keep_alive == YES) {
+#if TARGET_OS_IOS
         [options setObject:@(NO) forKey:GCDWebServerOption_AutomaticallySuspendInBackground];
+#endif
         [options setObject:@2.0 forKey:GCDWebServerOption_ConnectedStateCoalescingInterval];
     }
 

--- a/react-native-static-server.podspec
+++ b/react-native-static-server.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source         = { :git => 'https://github.com/futurepress/react-native-static-server.git' }
 
   s.requires_arc   = true
-  s.platform       = :ios, '7.0'
+  s.platforms      = { :ios => "7.0", :osx => "10.11" }
 
   s.preserve_paths = 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/*.{h,m}'


### PR DESCRIPTION
This PR makes some minor changes to be able to support this library on native MacOS apps if using Microsoft's [react-native-macos](https://github.com/microsoft/react-native-macos) library.