### PR TITLE
Ability to override Content-Type header for responses

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,24 +1,24 @@
 declare module 'react-native-static-server' {
   type Options = {
-    localOnly?: boolean;
-    keepAlive?: boolean;
-    mimeTypeOverrides?: Record<string, string>;
+    localOnly?: boolean
+    keepAlive?: boolean
+    mimeTypeOverrides?: Record<string, string>
   };
 
   export default class StaticServer {
-    constructor(port: number, root?: string, opts?: Options,);
+    constructor(port: number, root?: string, opts?: Options)
 
-    port: number;
-    root: string;
-    localOnly: boolean;
-    keepAlive: boolean;
-    started: boolean;
-    _origin?: string;
-    mimeTypeOverrides: Record<string, string>;
+    port: number
+    root: string
+    localOnly: boolean
+    keepAlive: boolean
+    started: boolean
+    _origin?: string
+    mimeTypeOverrides: Record<string, string>
 
-    start: () => Promise<string>;
-    stop: () => Promise<any>;
-    isRunning: () => Promise<boolean>;
-    kill: () => void;
+    start: () => Promise<string>
+    stop: () => Promise<any>
+    isRunning: () => Promise<boolean>
+    kill: () => void
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,13 @@
 declare module 'react-native-static-server' {
   type Options = {
-<<<<<<< HEAD
     localOnly?: boolean
     keepAlive?: boolean
     mimeTypeOverrides?: Record<string, string>
-=======
-    localOnly?: boolean;
-    keepAlive?: boolean;
-    mimeTypeOverrides?: Record<string, string>;
->>>>>>> d05a67501a63b4a14ecb6f3890cf9a96fbd7da9b
   };
 
   export default class StaticServer {
-    constructor(port: number, root?: string, opts?: Options,);
+    constructor(port: number, root?: string, opts?: Options)
 
-<<<<<<< HEAD
     port: number
     root: string
     localOnly: boolean
@@ -22,19 +15,10 @@ declare module 'react-native-static-server' {
     started: boolean
     _origin?: string
     mimeTypeOverrides: Record<string, string>
-=======
-    port: number;
-    root: string;
-    localOnly: boolean;
-    keepAlive: boolean;
-    started: boolean;
-    _origin?: string;
-    mimeTypeOverrides: Record<string, string>;
->>>>>>> d05a67501a63b4a14ecb6f3890cf9a96fbd7da9b
 
-    start: () => Promise<string>;
-    stop: () => Promise<any>;
-    isRunning: () => Promise<boolean>;
-    kill: () => void;
+    start: () => Promise<string>
+    stop: () => Promise<any>
+    isRunning: () => Promise<boolean>
+    kill: () => void
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,22 +1,24 @@
 declare module 'react-native-static-server' {
   type Options = {
-    localOnly?: boolean
-    keepAlive?: boolean
-  }
+    localOnly?: boolean;
+    keepAlive?: boolean;
+    mimeTypeOverrides?: Record<string, string>;
+  };
 
   export default class StaticServer {
-    constructor(port: number, root?: string, opts?: Options)
+    constructor(port: number, root?: string, opts?: Options,);
 
-    port: number
-    root: string
-    localOnly: boolean
-    keepAlive: boolean
-    started: boolean
-    _origin?: string
+    port: number;
+    root: string;
+    localOnly: boolean;
+    keepAlive: boolean;
+    started: boolean;
+    _origin?: string;
+    mimeTypeOverrides: Record<string, string>;
 
-    start: () => Promise<string>
-    stop: () => Promise<any>
-    isRunning: () => Promise<boolean>
-    kill: () => void
+    start: () => Promise<string>;
+    stop: () => Promise<any>;
+    isRunning: () => Promise<boolean>;
+    kill: () => void;
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import {
 	NativeModules,
 	AppState,
 	Platform
- } from 'react-native';
+} from 'react-native';
 
 const { FPStaticServer } = NativeModules;
 
@@ -18,30 +18,35 @@ class StaticServer {
 				this.root = root || ROOT;
 				this.localOnly = (opts && opts.localOnly) || false;
 				this.keepAlive = (opts && opts.keepAlive) || false;
+				this.mimeTypeOverrides = opts.mimeTypeOverrides || null;
 				break;
 			case 2:
 				this.port = `${port}`;
-				if (typeof(arguments[1]) === 'string') {
+				if (typeof (arguments[1]) === 'string') {
 					this.root = root;
 					this.localOnly = false;
 					this.keepAlive = false;
+					this.mimeTypeOverrides = null;
 				} else {
 					this.root = ROOT;
 					this.localOnly = (arguments[1] && arguments[1].localOnly) || false;
 					this.keepAlive = (arguments[1] && arguments[1].keepAlive) || false;
+					this.mimeTypeOverrides = arguments[1].mimeTypeOverrides || null;
 				}
 				break;
 			case 1:
-				if (typeof(arguments[0]) === 'number') {
+				if (typeof (arguments[0]) === 'number') {
 					this.port = `${port}`;
 					this.root = ROOT;
 					this.localOnly = false;
 					this.keepAlive = false;
+					this.mimeTypeOverrides = null;
 				} else {
 					this.port = PORT;
 					this.root = ROOT;
 					this.localOnly = (arguments[0] && arguments[0].localOnly) || false;
 					this.keepAlive = (arguments[0] && arguments[0].keepAlive) || false;
+					this.mimeTypeOverrides = arguments[0].mimeTypeOverrides || null;
 				}
 				break;
 			default:
@@ -49,6 +54,7 @@ class StaticServer {
 				this.root = ROOT;
 				this.localOnly = false;
 				this.keepAlive = false;
+				this.mimeTypeOverrides = null;
 		}
 
 
@@ -58,7 +64,7 @@ class StaticServer {
 	}
 
 	start() {
-		if( this.running ){
+		if (this.running) {
 			return Promise.resolve(this.origin);
 		}
 
@@ -69,7 +75,7 @@ class StaticServer {
 			AppState.addEventListener('change', this._handleAppStateChangeFn);
 		}
 
-		return FPStaticServer.start(this.port, this.root, this.localOnly, this.keepAlive)
+		return FPStaticServer.start(this.port, this.root, this.localOnly, this.keepAlive, this.mimeTypeOverrides)
 			.then((origin) => {
 				this._origin = origin;
 				return origin;

--- a/ios/FPStaticServer.h
+++ b/ios/FPStaticServer.h
@@ -6,17 +6,18 @@
 #import "GCDWebServerFileResponse.h"
 #import "GCDWebServerHTTPStatusCodes.h"
 
-@interface FPStaticServer : NSObject <RCTBridgeModule> {
-    GCDWebServer* _webServer;
+@interface FPStaticServer : NSObject <RCTBridgeModule>
+{
+    GCDWebServer *_webServer;
 }
 
-    @property(nonatomic, retain) NSString *localPath;
-    @property(nonatomic, retain) NSString *url;
+@property(nonatomic, retain) NSString *localPath;
+@property(nonatomic, retain) NSString *url;
 
-    @property (nonatomic, retain) NSString* www_root;
-    @property (nonatomic, retain) NSNumber* port;
-    @property (assign) BOOL localhost_only;
-    @property (assign) BOOL keep_alive;
+@property(nonatomic, retain) NSString *www_root;
+@property(nonatomic, retain) NSNumber *port;
+@property(nonatomic, retain) NSDictionary<NSString *, NSString *> *mime_type_overrides;
+@property(assign) BOOL localhost_only;
+@property(assign) BOOL keep_alive;
 
 @end
-  

--- a/ios/FPStaticServer.m
+++ b/ios/FPStaticServer.m
@@ -30,10 +30,11 @@ RCT_EXPORT_MODULE();
 }
 
 
-RCT_EXPORT_METHOD(start: (NSString *)port
+RCT_EXPORT_METHOD(start:(NSString *)port
                   root:(NSString *)optroot
                   localOnly:(BOOL *)localhost_only
                   keepAlive:(BOOL *)keep_alive
+                  mimeTypeOverrides:(NSDictionary *)mime_type_overrides
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
 
@@ -67,12 +68,14 @@ RCT_EXPORT_METHOD(start: (NSString *)port
 
     self.localhost_only = localhost_only;
 
+    self.mime_type_overrides = mime_type_overrides;
+
     if(_webServer.isRunning != NO) {
         NSLog(@"StaticServer already running at %@", self.url);
         resolve(self.url);
         return;
     }
-
+     
     //[_webServer addGETHandlerForBasePath:@"/" directoryPath:self.www_root indexFilename:@"index.html" cacheAge:3600 allowRangeRequests:YES];
     NSString *basePath = @"/";
     NSString *directoryPath = self.www_root;
@@ -104,11 +107,11 @@ RCT_EXPORT_METHOD(start: (NSString *)port
               response = [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_NotFound];
             }
           } else if ([fileType isEqualToString:NSFileTypeRegular]) {
-            if (allowRangeRequests) {
-              response = [GCDWebServerFileResponse responseWithFile:filePath byteRange:request.byteRange];
+          if (allowRangeRequests) {
+              response = [[GCDWebServerFileResponse alloc] initWithFile:filePath byteRange:request.byteRange isAttachment:NO mimeTypeOverrides:mime_type_overrides] ;
               [response setValue:@"bytes" forAdditionalHeader:@"Accept-Ranges"];
             } else {
-              response = [GCDWebServerFileResponse responseWithFile:filePath];
+              response = [[GCDWebServerFileResponse alloc] initWithFile:filePath byteRange:NSMakeRange(NSUIntegerMax, 0) isAttachment:NO mimeTypeOverrides:mime_type_overrides];
             }
           }
         }


### PR DESCRIPTION
**Description**

`GCDWebServer` provided the method that allows overriding the MIME types but `react-native-static-server` didn’t expose that capability, I added the optional `mimeTypeOverrides` argument to give the ability to override response’s Content-Type header.

**Motivation and Context**

When I tried to use this to set up our local server, it failed to set the correct `Content-Type` header for responses returning XML files. It sets `application/octet-stream` instead of `application/xml` as `XMLHttpRequest` expects.
The root cause is that `GCDWebServer` sets the response’s `Content-Type` header to `application/octet-stream` for all file types, except for a few well-known ones such as HTML or CSS. Therefore, I implemented a simple change as described above to set the correct Content-Type header for responses .
